### PR TITLE
feat: Add async listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,27 @@ bus.on('error', (err) => {
 
 bus.emit('error', new Error('Something went wrong'));
 ```
+
+### Asynchronous listeners
+
+```ts
+import { EventBus } from "simply-typed-universal-bus";
+
+interface MyEvents {
+    data: { id: number, value: string };
+}
+
+const bus = new EventBus<MyEvents>();
+
+bus.on('data', async (payload) => {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    console.log(`Received async data, id: ${payload.id}, value: ${payload.value}`);
+});
+
+// emit asynchronously
+(async () => {
+    console.log(`Emitting asynchronously`);
+    await bus.emitAsync('data', { id: 1, value: 'Hello World' });
+    console.log('Complete');
+})();
+```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "Jacob Massengill",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "typescript": "^5.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simply-typed-universal-bus",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/stub.js",
   "repository": {

--- a/src/examples/async.ts
+++ b/src/examples/async.ts
@@ -1,0 +1,34 @@
+import { EventBus } from "../stub.js";
+
+interface MyEvents {
+    data: { id: number, value: string };
+}
+
+const bus = new EventBus<MyEvents>();
+
+// listen for 'data' event
+
+bus.on('data', (payload) => {
+    console.log(`Received id: ${payload.id}, value: ${payload.value}`);
+});
+
+bus.on('data', async (payload) => {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    console.log(`Received async data, id: ${payload.id}, value: ${payload.value}`);
+});
+
+// emit synchronously
+console.log(`Emitting synchronously`);
+bus.emit('data', { id: 1, value: 'Hello World' });
+console.log('Complete');
+
+// emit asynchronously
+(async () => {
+
+    // wait for synchronous emit to complete
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    console.log(`Emitting asynchronously`);
+    await bus.emitAsync('data', { id: 1, value: 'Hello World' });
+    console.log('Complete');
+})();

--- a/src/examples/example.ts
+++ b/src/examples/example.ts
@@ -1,4 +1,4 @@
-import { EventBus } from '../stub';
+import { EventBus } from '../stub.js';
 
 // Define the events and payload types.
 interface MyEvents {

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -5,7 +5,7 @@ export interface EventTypeMap {
 
 export class EventBus<T extends EventTypeMap> {
     private listeners: {
-        [K in keyof T]?: Array<(payload: T[K]) => void>;
+        [K in keyof T]?: Array<(payload: T[K]) => void | Promise<void>>;
     } = {};
 
     // Subscribe to an event.
@@ -30,4 +30,12 @@ export class EventBus<T extends EventTypeMap> {
             }
         }
     }
+
+    // Emit an event and listen asynchronously
+    async emitAsync<K extends keyof T>(event: K, payload: T[K]): Promise<void> {
+        if (this.listeners[event]) {
+            await Promise.all(this.listeners[event].map(listener => listener(payload)));
+        }
+    }
+
 }


### PR DESCRIPTION
adds:

- `emitAsync` to allow for asynchronous listeners
-  example usage for `emitAsync`