### PR TITLE
feat: No single listener fails emit call

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ bus.on('data', async (payload) => {
 
 ### Listener prioritization
 
-The order in which listeners are invoked can be constrolled with the `priority` listener option. The higher the priority, the sooner the listener is evoked during `emit`. 
+The order in which listeners are invoked can be controlled with the `priority` listener option. The higher the priority, the sooner the listener is evoked during `emit`. 
 
 ```ts
 import { EventBus } from "simply-typed-universal-bus";
@@ -89,3 +89,89 @@ bus.emit('data', 'testing priority');
 
 There are three methods for removing listeners. Use `off` to remove a single listener. Give a reference to the listener to remove it. Use `removeAllListenersForEvent` to remove all listeners for a particular event.
 Use `removeAllListeners` to remove all listeners from all events.
+
+## Error handling
+
+Errors can be handled in one of two ways; either through a global error handler that is applied to every error encountered during `emit` or `emitAsync`, or by checking the return values of `emit` or `emitAsync`. 
+
+### Global error handling
+
+```ts
+    import { EventBus } from 'simply-typed-universal-bus';
+
+    interface MyEvents {
+        data: string;
+    }
+
+    const bus = new EventBus<MyEvents>();
+
+    bus.on('data', () => {
+        throw new Error('simulated error');
+    });
+
+    const errorHandler = (error: Error, event: keyof MyEvents, payload: MyEvents[keyof MyEvents]) => {
+        console.error(`Error occurred in event "${event}": ${error.message}`);
+        console.error(`Payload: ${JSON.stringify(payload)}`);
+    }
+    bus.setErrorHandler(errorHandler);
+
+    // prints out:
+    // Error occurred in event "data": simulated error
+    // Payload: "Hello, world!"
+    bus.emit('data', 'Hello, world!');
+```
+
+### Error handling through return value
+
+```ts
+    import { EventBus } from 'simply-typed-universal-bus';
+
+    interface MyEvents {
+        data: string;
+    }
+
+    const bus = new EventBus<MyEvents>(); 
+
+    bus.on('data', () => {
+        throw new Error('error1');
+    });
+   
+    bus.on('data', () => {
+        throw new Error('error2');
+    });
+
+    const errors = bus.emit('data', 'hello world');
+
+    for(error in errors) {
+        console.log(`Received error: ${error.message}`);
+    }
+```
+### Abort listeners on error
+
+You also have the option to halt listeners during `emit` by using the `abortAllOnError` listener option. When this option is enabled and an error is encountered during the invocation of the listener, the error is thrown back to the `emit` caller. Note the global error handler is still called when this option is enabled. 
+
+```ts
+import { EventBus } from "simply-typed-universal-bus";
+
+interface MyEvents {
+    data: string;
+}
+const bus = new EventBus<MyEvents>();
+
+bus.on('data', () => {
+    console.log('I was registered first!');
+    throw new Error('I am an error!');
+}, { abortAllOnError: true });
+
+bus.on('data', () => {
+    console.log('I was registered second!');
+});
+
+// prints 'I was registered first!' then throws an error
+try {
+    bus.emit('data', 'testing abortAllOnError');
+}
+catch (error) {
+    console.error(`Caught an error: ${(error as Error).message}`);
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simply-typed-universal-bus",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "",
   "main": "dist/stub.js",
   "repository": {

--- a/src/examples/abortOnError.ts
+++ b/src/examples/abortOnError.ts
@@ -1,0 +1,23 @@
+import { EventBus } from "../stub.js";
+
+interface MyEvents {
+    data: string;
+}
+const bus = new EventBus<MyEvents>();
+
+bus.on('data', () => {
+    console.log('I was registered first!');
+    throw new Error('I am an error!');
+}, { abortAllOnError: true });
+
+bus.on('data', () => {
+    console.log('I was registered second!');
+});
+
+// prints 'I was registered first!' then throws an error
+try {
+    bus.emit('data', 'testing abortAllOnError');
+}
+catch (error) {
+    console.error(`Caught an error: ${(error as Error).message}`);
+}

--- a/src/examples/globalErrorHandling.ts
+++ b/src/examples/globalErrorHandling.ts
@@ -1,0 +1,23 @@
+import { EventBus } from '../stub.js';
+
+interface MyEvents {
+    data: string;
+}
+
+const bus = new EventBus<MyEvents>();
+
+bus.on('data', () => {
+    throw new Error('simulated error');
+});
+
+bus.on('data', (payload) => {
+    console.log(`Received data: ${payload}`);
+});
+
+const errorHandler = (error: Error, event: keyof MyEvents, payload: MyEvents[keyof MyEvents]) => {
+    console.error(`Error occurred in event "${event}": ${error.message}`);
+    console.error(`Payload: ${JSON.stringify(payload)}`);
+}
+bus.setErrorHandler(errorHandler);
+
+bus.emit('data', 'Hello, world!');

--- a/src/stub.test.ts
+++ b/src/stub.test.ts
@@ -119,4 +119,27 @@ describe('EventBus', () => {
 
         expect(listener2).not.toHaveBeenCalled();
     });
+
+    it('should call global error handler', () => {
+        const listener = jest.fn(() => { throw new Error('test'); });
+        const globalErrorHandler = jest.fn();
+
+        testBus.setErrorHandler(globalErrorHandler);
+        testBus.on('data', listener);
+
+        testBus.emit('data', 'test');
+
+        expect(globalErrorHandler).toHaveBeenCalled();
+    });
+
+    it('should return errors from emit', () => {
+        const listener = jest.fn(() => { throw new Error('test'); });
+        const listener2 = jest.fn(() => { throw new Error('test2'); });
+        testBus.on('data', listener);
+        testBus.on('data', listener2);
+        const errors = testBus.emit('data', 'test');
+        expect(errors).toHaveLength(2);
+        expect(errors[0].message).toBe('test');
+        expect(errors[1].message).toBe('test2');
+    });
 });

--- a/src/stub.test.ts
+++ b/src/stub.test.ts
@@ -92,4 +92,31 @@ describe('EventBus', () => {
         expect(listener1).not.toHaveBeenCalled();
         expect(listener2).not.toHaveBeenCalled();
     });
+
+    it('should not throw when emitting an event', () => {
+        const listener = jest.fn(() => { throw new Error('test'); });
+        testBus.on('data', listener);
+
+        expect(async () => {
+            testBus.emit('data', 'test');
+            await testBus.emitAsync('data', 'test');
+        }).not.toThrow();
+    });
+
+    it('should throw when abortAllOnError is true', () => {
+        const listener = jest.fn(() => { throw new Error('test'); });
+        const listener2 = jest.fn();
+        testBus.on('data', listener, { abortAllOnError: true });
+        testBus.on('data', listener2);
+
+        expect(() => {
+            testBus.emit('data', 'test');
+        }).toThrow();
+
+        expect(async () => {
+            await testBus.emitAsync('data', 'test');
+        }).rejects.toThrow();
+
+        expect(listener2).not.toHaveBeenCalled();
+    });
 });

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -71,9 +71,9 @@ export class EventBus<T extends EventTypeMap> {
             return errors;
         }
 
-        await Promise.all(this.listeners[event].map(({ listener, abortAllOnError }) => {
+        await Promise.all(this.listeners[event].map(async ({ listener, abortAllOnError }) => {
             try {
-                listener(payload);
+                await listener(payload);
             } catch (error) {
 
                 const err = error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
adds better error handling
adds a  global error handler that is user defined
adds the ability to halt listener execution when desired
changes the return type of `emit` to `Error[]` and `emitAsync` to `Promise<Error[]>`