### PR TITLE
feat: add on error callback listener option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Use `removeAllListeners` to remove all listeners from all events.
 
 ## Error handling
 
-Errors can be handled in one of two ways; either through a global error handler that is applied to every error encountered during `emit` or `emitAsync`, or by checking the return values of `emit` or `emitAsync`. 
+Errors can be handled in one of three ways; either through a global error handler that is applied to every error encountered during `emit` or `emitAsync`, by checking the return values of `emit` or `emitAsync`, or by providing the `onError` listener option. 
 
 ### Global error handling
 
@@ -146,6 +146,31 @@ Errors can be handled in one of two ways; either through a global error handler 
         console.log(`Received error: ${error.message}`);
     }
 ```
+
+### Error handling through onError callback
+
+Note that the global error handler is still invoked when this option is provided, and will be invoked even when `abortAllOnError` is true. 
+
+```ts
+    import { EventBus } from 'simply-typed-universal-bus';
+
+    interface MyEvents {
+        data: string;
+    }
+
+    const bus = new EventBus<MyEvents>(); 
+
+    bus.on('data', () => {
+        throw new Error('error1');
+    }, {
+        onError: (err: Error, payload: MyEvents['data']) => {
+            console.log(`received error: ${error.message} on payload: ${payload}`);
+        }
+    });
+
+    const errors = bus.emit('data', 'hello world');
+```
+
 ### Abort listeners on error
 
 You also have the option to halt listeners during `emit` by using the `abortAllOnError` listener option. When this option is enabled and an error is encountered during the invocation of the listener, the error is thrown back to the `emit` caller. Note the global error handler is still called when this option is enabled. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simply-typed-universal-bus",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "dist/stub.js",
   "repository": {

--- a/src/stub.test.ts
+++ b/src/stub.test.ts
@@ -103,9 +103,9 @@ describe('EventBus', () => {
         }).not.toThrow();
     });
 
-    it.only('should throw when abortAllOnError is true', () => {
-        const listener = jest.fn(() => { console.log('listener1'); throw new Error('test error'); });
-        const listener2 = jest.fn(() => { console.log('listener2'); });
+    it('should throw when abortAllOnError is true', () => {
+        const listener = jest.fn(() => { throw new Error('test error'); });
+        const listener2 = jest.fn();
         testBus.on('data', listener, { abortAllOnError: true });
         testBus.on('data', listener2);
 
@@ -149,6 +149,18 @@ describe('EventBus', () => {
         testBus.on('data', listener, { onError });
 
         testBus.emit('data', 'test');
+
+        expect(onError).toHaveBeenCalledWith(expect.any(Error), 'test');
+    });
+
+    it('should invoke onError callback even when abortAllOnError is true', () => {
+        const listener = jest.fn(() => { throw new Error('test'); });
+        const onError = jest.fn();
+        testBus.on('data', listener, { onError, abortAllOnError: true });
+
+        expect(() => {
+            testBus.emit('data', 'test');
+        }).toThrow();
 
         expect(onError).toHaveBeenCalledWith(expect.any(Error), 'test');
     });

--- a/src/stub.test.ts
+++ b/src/stub.test.ts
@@ -103,9 +103,9 @@ describe('EventBus', () => {
         }).not.toThrow();
     });
 
-    it('should throw when abortAllOnError is true', () => {
-        const listener = jest.fn(() => { throw new Error('test'); });
-        const listener2 = jest.fn();
+    it.only('should throw when abortAllOnError is true', () => {
+        const listener = jest.fn(() => { console.log('listener1'); throw new Error('test error'); });
+        const listener2 = jest.fn(() => { console.log('listener2'); });
         testBus.on('data', listener, { abortAllOnError: true });
         testBus.on('data', listener2);
 
@@ -141,5 +141,15 @@ describe('EventBus', () => {
         expect(errors).toHaveLength(2);
         expect(errors[0].message).toBe('test');
         expect(errors[1].message).toBe('test2');
+    });
+
+    it('should invoke onError callback on error', () => {
+        const listener = jest.fn(() => { throw new Error('test'); });
+        const onError = jest.fn();
+        testBus.on('data', listener, { onError });
+
+        testBus.emit('data', 'test');
+
+        expect(onError).toHaveBeenCalledWith(expect.any(Error), 'test');
     });
 });

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -75,7 +75,7 @@ export class EventBus<T extends EventTypeMap> {
             return errors;
         }
 
-        await Promise.all(this.listeners[event].map(async ({ listener, abortAllOnError, onError }) => {
+        for (const { listener, abortAllOnError, onError } of this.listeners[event]!) {
             try {
                 await listener(payload);
             } catch (error) {
@@ -95,7 +95,7 @@ export class EventBus<T extends EventTypeMap> {
                     throw error;
                 }
             }
-        }));
+        }
 
         return errors;
     }


### PR DESCRIPTION
also makes `emitAsync` run listeners sequentially so `abortAllOnError` works properly. 